### PR TITLE
entriesBuilder from Build

### DIFF
--- a/packages/framework/src/backend/build/build/development.ts
+++ b/packages/framework/src/backend/build/build/development.ts
@@ -30,12 +30,10 @@ export class DevelopmentBuild extends Build {
     let errorPageBuilder = new DevErrorPageBuilder();
     let rscBuilder = new RSCBuilder({
       build: this,
-      entriesBuilder,
     });
 
     let clientBuilder = new ClientBuilder({
       build: this,
-      entriesBuilder,
     });
     let serverFilesBuilder = new ServerFilesBuilder({
       build: this,

--- a/packages/framework/src/backend/build/builders/client-builder.ts
+++ b/packages/framework/src/backend/build/builders/client-builder.ts
@@ -12,34 +12,33 @@ import * as mime from "mime-types";
 import { fileURLToEscapedPath, hashFile } from "../helpers/file.js";
 import { transform } from "esbuild";
 import { transformAsync } from "@babel/core";
-import { EntriesBuilder } from "./entries-builder.js";
 
 export class ClientBuilder extends Builder {
   readonly name = "client";
 
   #build: Build;
-  #entriesBuilder: EntriesBuilder;
   #outputs?: Output[] | undefined;
 
   #imagesMap = new Map<string, Image>();
 
   constructor({
     build,
-    entriesBuilder,
   }: {
     build: Build;
-    entriesBuilder: EntriesBuilder;
   }) {
     super();
     this.#build = build;
-    this.#entriesBuilder = entriesBuilder;
   }
 
   get clientEntryPoints() {
-    let files = Array.from(this.#entriesBuilder.clientComponentEntryMap.keys());
+    let files = Array.from(this.entriesBuilder.clientComponentEntryMap.keys());
 
     // entry point order matters for deterministic builds
     return files.sort();
+  }
+
+  get entriesBuilder() {
+    return this.#build.getBuilder("entries");
   }
 
   get #env() {
@@ -410,7 +409,7 @@ export class ClientBuilder extends Builder {
     }
 
     let clientComponents = Array.from(
-      this.#entriesBuilder.clientComponentEntryMap.values(),
+      this.entriesBuilder.clientComponentEntryMap.values(),
     );
     let clientComponentModuleMap = new Map<
       string,
@@ -453,7 +452,7 @@ export class ClientBuilder extends Builder {
     // }
 
     let clientComponents = Array.from(
-      this.#entriesBuilder.clientComponentEntryMap.values(),
+      this.entriesBuilder.clientComponentEntryMap.values(),
     );
     let clientComponentMap = new Map<
       string,

--- a/packages/framework/src/backend/build/builders/rsc-builder.ts
+++ b/packages/framework/src/backend/build/builders/rsc-builder.ts
@@ -22,7 +22,6 @@ import { esbuildPluginTailwind } from "@ryanto/esbuild-plugin-tailwind";
 import { Image, imagesPlugin } from "../plugins/images-plugin.js";
 import { Font, fontsPlugin } from "../plugins/fonts-plugin.js";
 import { excludePackages } from "../externals/predefined-externals.js";
-import { EntriesBuilder } from "./entries-builder.js";
 import { ErrorTemplate } from "../rsc/error-template.js";
 import { Generic } from "../rsc/generic.js";
 import { CatchBoundary } from "../rsc/catch-boundary.js";
@@ -40,21 +39,17 @@ export class RSCBuilder extends Builder {
   readonly name = "rsc";
 
   #metafile?: Metafile | undefined;
-  #entriesBuilder: EntriesBuilder;
   #build: Build;
   #serverActionMap = new Map<string, CompiledAction>();
   #imagesMap = new Map<string, Image>();
   #fontsMap = new Map<string, Font>();
 
   constructor({
-    entriesBuilder,
     build,
   }: {
-    entriesBuilder: EntriesBuilder;
     build: Build;
   }) {
     super();
-    this.#entriesBuilder = entriesBuilder;
     this.#build = build;
   }
 
@@ -70,8 +65,8 @@ export class RSCBuilder extends Builder {
     return this.#fontsMap;
   }
 
-  get entries() {
-    return this.#entriesBuilder;
+  get entriesBuilder() {
+    return this.#build.getBuilder("entries");
   }
 
   async setup() {}
@@ -88,7 +83,7 @@ export class RSCBuilder extends Builder {
 
     // files need to be sorted for deterministic builds
     let serverActionEntries = Array.from(
-      this.#entriesBuilder.serverActionEntryMap.keys(),
+      this.entriesBuilder.serverActionEntryMap.keys(),
     ).sort();
 
     this.#serverActionMap = new Map();
@@ -100,7 +95,7 @@ export class RSCBuilder extends Builder {
     try {
       let appConfig = await this.#build.getAppConfig();
       let userDefinedExternalPackages = appConfig.externalPackages ?? [];
-      let discoveredExternals = this.#entriesBuilder.discoveredExternals;
+      let discoveredExternals = this.entriesBuilder.discoveredExternals;
 
       let result = await build({
         bundle: true,
@@ -179,7 +174,7 @@ export class RSCBuilder extends Builder {
               let errorsRegex = `^${fileURLToEscapedPath(pagesDir)}/.*\\.error\\.tsx$`;
 
               function isClientComponent(file: string) {
-                return builder.#entriesBuilder.clientComponentEntryMap.has(
+                return builder.entriesBuilder.clientComponentEntryMap.has(
                   file,
                 );
               }


### PR DESCRIPTION
I saw the builders came with two parameters build, and entriesBuilder. But if you add the build to builder as parameter. You can access the entries builder from the build. So you dont need to pass as parameter. It's good to change, because you make a custom entriesBuilder, and put it into build, crashes the build process. Because you will have two different entriesBuilders in the same build process. 