### PR TITLE
programmatically run dev or production

### DIFF
--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -34,6 +34,11 @@
     "./redirect": "./src/client/http/redirect.ts",
     "./encryption": "./dist/backend/encryption.js",
     "./context/page": "./src/client/server-context/page.ts",
+    "./run/dev": "./dist/backend/tasks/dev.js",
+    "./run/serve": "./dist/backend/tasks/serve.js",
+    "./build/dev": "./dist/backend/build/build/development.js",
+    "./build/production": "./dist/backend/build/build/production.js",
+    "./builders/*": "./dist/backend/build/builders/*.js",
     "./flash": {
       "react-server": "./src/client/actions/flash.ts",
       "default": "./src/client/actions/flash-client.ts"


### PR DESCRIPTION
This is not completed, absolutely. Need to add some types for the framework, but it works. If you familiar with this, i suggest this feature to complete the whole accessability with types.
For example:
```
import { DevTask } from "@twofold/framework/run/dev";
import { DevelopmentBuild } from "@twofold/framework/build/dev";
import { EntriesBuilder } from "@twofold/framework/builders/entries-builder";

class CustomEntriesBuilder extends EntriesBuilder {
    constructor({ build }) {
        super({ build });
    }
    async build() {
        await super.build();
        //this.#clientComponentEntryMap.set('index', 'index.tsx');
    }

    get clientComponentEntryMap() {
        //super.clientComponentEntryMap.set('index', 'index.tsx');
        return super.clientComponentEntryMap;
    }

    get serverActionEntryMap() {
        //super.serverActionEntryMap.set('index', 'index.tsx');
        return super.serverActionEntryMap;
    }
}

(async () => {
    const build = new DevelopmentBuild();
    const entries = new CustomEntriesBuilder({
        build
    });
    build.addBuilder(entries);
    const dev = new DevTask({
        build: build,
        port: 3000,
    });
    dev.start();
    setTimeout(() => {
        console.log(entries.clientComponentEntryMap);
        console.log(entries.serverActionEntryMap);
    }, 2000);
})();
```
(PS.: I tried to add types with tsc or esbuild-plugin-d.ts with the compile.js (in pnpm command) but it failed.)