### PR TITLE
Implement authentication policies

### DIFF
--- a/examples/kitchen-sink/app/auth.ts
+++ b/examples/kitchen-sink/app/auth.ts
@@ -1,0 +1,101 @@
+import cookies from "@twofold/framework/cookies";
+import { allow, AuthPolicyProps, AuthPolicyResult, deny, response } from "@twofold/framework/auth";
+import { redirect } from "@twofold/framework/redirect";
+
+/**
+ * This is an example of an authentication policy that layouts, pages, actions and routes can optionally use by exporting a 'const auth: AuthPolicyArray = [allowIfCookieSet]'. Non-default auth policies don't have to be specified in this file, but it's a convention so you know where all your authentication code is.
+ * 
+ * Authentication policies exported from layouts, pages, actions and routes by default inherit the authentication policies from their parent layouts and the root authentication policy.
+ * 
+ * If you want a specific route to discard all of it's authentication policies, you can use the special 'reset' value, like so:
+ * 
+ * import { reset } from "@twofold/framework/auth";
+ * export const auth: AuthPolicyArray = [reset, otherPolicy];
+ * 
+ * @param props The authentication properties.
+ * @returns The policy result.
+ */
+export async function allowIfCookieSet({request}: AuthPolicyProps): Promise<AuthPolicyResult> {
+  // This is an example of an auth policy that changes it's behaviour based on the request.
+  if (cookies.get('allow-access') === 'true') {
+    return allow();
+  } else {
+    return deny("missing cookie");
+  }
+}
+
+export async function behaveBasedOnQueryString({request}: AuthPolicyProps): Promise<AuthPolicyResult> {
+  // This policy changes it's behaviour based on the query string, and is used for the protected/ content under this app (in addition to the other policies here).
+  const url = new URL(request.url);
+  switch (url.searchParams.get("auth-behaviour")) {
+    case "response":
+      return response(new Response("Access denied by behaveBasedOnQueryString (response)"));
+    case "response-throw":
+      throw new Response("Access denied by behaveBasedOnQueryString (response-throw).");
+    case "deny":
+      return deny("Access denied by behaveBasedOnQueryString (deny).");
+    case "deny-throw":
+      throw "Access denied by behaveBasedOnQueryString (deny-throw).";
+    case "error":
+      throw new Error("This is an unhandled error for behaveBasedOnQueryString (error).");
+    case "redirect":
+      redirect("/");
+    case "allow":
+    default:
+      return allow();
+  }
+}
+
+export async function behaveBasedOnFormData({request}: AuthPolicyProps): Promise<AuthPolicyResult> {
+  // This policy changes it's behaviour based on the 'behaviour' form data, which is how we demonstrate different behaviour for server actions.
+  const formData = await request.formData();
+
+  // @note: This is '1_behaviour', due to the way React encodes form data fields. Since you're not expected to actually do auth based on form fields, it's fine as a workaround for the example app.
+  switch (formData.get("1_behaviour")) {
+    case "response":
+      return response(new Response("Access denied by behaveBasedOnQueryString (response)"));
+    case "response-throw":
+      throw new Response("Access denied by behaveBasedOnQueryString (response-throw).");
+    case "deny":
+      return deny("Access denied by behaveBasedOnQueryString (deny).");
+    case "deny-throw":
+      throw "Access denied by behaveBasedOnQueryString (deny-throw).";
+    case "error":
+      throw new Error("This is an unhandled error for behaveBasedOnQueryString (error).");
+    case "redirect":
+      redirect("/");
+    case "allow":
+    default:
+      return allow();
+  }
+}
+
+/**
+ * The default export from auth.ts is the root authentication policy that applies to all layouts, pages, actions and routes.
+ * 
+ * @param props The authentication properties.
+ * @returns The policy result.
+ */
+export default async function defaultPolicy(props: AuthPolicyProps) : Promise<AuthPolicyResult> {
+  // This is the default behaviour when auth.ts is not specified.
+  return allow();
+
+  // e.g. deny access with message (message passed to 'access denied' default page)
+  //
+  // return deny("not signed in");
+
+  // e.g. return a direct response for all but server actions
+  //
+  // return response(Response.redirect("/", 302));
+
+  // e.g. throwing an error results in deny
+  //
+  // throw new Error("some message");
+
+  // e.g. throwing a response to return the response
+  //
+  // throw Response.redirect("/", 302);
+
+  // returning no value is not permitted per the type system, but
+  // if you do, it's treated as deny
+}

--- a/examples/kitchen-sink/app/pages/auth/Control.tsx
+++ b/examples/kitchen-sink/app/pages/auth/Control.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import React, { ReactNode, useState, useTransition } from "react";
+import { clearCookie, setCookie } from "./cookie";
+import protectedAction from "./protected/action/protectedAction";
+import unprotectedAction from "./protected/unprotected/action/unprotectedAction";
+import { isServerActionUnauthorizedError } from "@twofold/framework/auth";
+
+function TestLink(props: { href: string }) {
+  return <a href={props.href} target="page-test" className="rounded bg-black px-2.5 py-1.5 text-sm font-medium text-white shadow mx-auto mt-2 mb-2 inline-block">Test</a>
+}
+
+function Td(props: { children: React.ReactNode }) {
+  return <td className="text-center">{props.children}</td>
+}
+
+function TestServerAction(props: { behaviour: string, startTransition: any, setComponent: any, unprotected?: boolean }) {
+  const submitAction = async (formData: FormData) => {
+    props.startTransition(async () => {
+      try {
+        let c = await (props.unprotected ? unprotectedAction : protectedAction)(formData);
+        props.setComponent(c);
+      } catch (err) {
+        if (isServerActionUnauthorizedError(err)) {
+          props.setComponent(<div>Request was unauthorized.</div>);
+        } else {
+          props.setComponent(<div>An error occurred: {err?.toString()}</div>);
+        }
+      }
+    });
+  }
+  return <form action={submitAction}>
+    <input name="behaviour" value={props.behaviour} type="hidden" />
+    <button
+      type="submit"
+      className="rounded bg-black px-2.5 py-1.5 text-sm font-medium text-white shadow mx-auto mt-2 mb-2 inline-block"
+    >
+      Test
+    </button>
+  </form>
+}
+
+export default function Control(props: { allowIfCookieSetWillPass: boolean }) {
+  let [component, setComponent] = useState<ReactNode>();
+  let [isPending, startTransition] = useTransition();
+
+  return <div>
+    <h1 className="text-4xl font-black tracking-tighter">Auth examples</h1>
+    <p className="mt-3">
+      General access to routes protected by <code>allowIfCookieSet</code>: {!props.allowIfCookieSetWillPass ? <span className="text-red-500">Denied</span> : <span className="text-green-500">Allowed</span>}
+    </p>
+    <form action={setCookie} className="mt-3">
+      <button
+        type="submit"
+        className="rounded bg-black px-2.5 py-1.5 text-sm font-medium text-white shadow"
+      >
+        Set cookie for general access
+      </button>
+    </form>
+    <form action={clearCookie} className="mt-3">
+      <button
+        type="submit"
+        className="rounded bg-black px-2.5 py-1.5 text-sm font-medium text-white shadow"
+      >
+        Remove cookie for general access
+      </button>
+    </form>
+
+    <h1 className="mt-10 text-3xl font-black tracking-tighter">Examples table</h1>
+    <table className="w-full mt-3">
+      <tr>
+        <th></th>
+        <th>None</th>
+        <th><code>response</code></th>
+        <th><code>response-throw</code></th>
+        <th><code>deny</code></th>
+        <th><code>deny-throw</code></th>
+        <th><code>error</code></th>
+        <th><code>redirect</code></th>
+        <th><code>allow</code></th>
+      </tr>
+      <tr>
+        <th>Page</th>
+        <Td>
+          <TestLink href="/auth/protected/page" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/page?auth-behaviour=response" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/page?auth-behaviour=response-throw" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/page?auth-behaviour=deny" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/page?auth-behaviour=deny-throw" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/page?auth-behaviour=error" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/page?auth-behaviour=redirect" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/page?auth-behaviour=allow" />
+        </Td>
+      </tr>
+      <tr>
+        <th>Server action</th>
+        <Td>
+          <TestServerAction startTransition={startTransition} setComponent={setComponent} behaviour="" />
+        </Td>
+        <Td>
+          <TestServerAction startTransition={startTransition} setComponent={setComponent} behaviour="response" />
+        </Td>
+        <Td>
+          <TestServerAction startTransition={startTransition} setComponent={setComponent} behaviour="response-throw" />
+        </Td>
+        <Td>
+          <TestServerAction startTransition={startTransition} setComponent={setComponent} behaviour="deny" />
+        </Td>
+        <Td>
+          <TestServerAction startTransition={startTransition} setComponent={setComponent} behaviour="deny-throw" />
+        </Td>
+        <Td>
+          <TestServerAction startTransition={startTransition} setComponent={setComponent} behaviour="error" />
+        </Td>
+        <Td>
+          <TestServerAction startTransition={startTransition} setComponent={setComponent} behaviour="redirect" />
+        </Td>
+        <Td>
+          <TestServerAction startTransition={startTransition} setComponent={setComponent} behaviour="allow" />
+        </Td>
+      </tr>
+      <tr>
+        <th>API route</th>
+        <Td>
+          <TestLink href="/auth/protected/api" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/api?auth-behaviour=response" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/api?auth-behaviour=response-throw" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/api?auth-behaviour=deny" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/api?auth-behaviour=deny-throw" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/api?auth-behaviour=error" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/api?auth-behaviour=redirect" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/api?auth-behaviour=allow" />
+        </Td>
+      </tr>
+      <tr style={{borderTop: 'solid 1px #000'}}>
+        <th>Unprotected page</th>
+        <Td>
+          <TestLink href="/auth/protected/unprotected/page" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/unprotected/page?auth-behaviour=response" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/unprotected/page?auth-behaviour=response-throw" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/unprotected/page?auth-behaviour=deny" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/unprotected/page?auth-behaviour=deny-throw" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/unprotected/page?auth-behaviour=error" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/unprotected/page?auth-behaviour=redirect" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/unprotected/page?auth-behaviour=allow" />
+        </Td>
+      </tr>
+      <tr>
+        <th>Unprotected server action</th>
+        <Td>
+          <TestServerAction unprotected startTransition={startTransition} setComponent={setComponent} behaviour="" />
+        </Td>
+        <Td>
+          <TestServerAction unprotected startTransition={startTransition} setComponent={setComponent} behaviour="response" />
+        </Td>
+        <Td>
+          <TestServerAction unprotected startTransition={startTransition} setComponent={setComponent} behaviour="response-throw" />
+        </Td>
+        <Td>
+          <TestServerAction unprotected startTransition={startTransition} setComponent={setComponent} behaviour="deny" />
+        </Td>
+        <Td>
+          <TestServerAction unprotected startTransition={startTransition} setComponent={setComponent} behaviour="deny-throw" />
+        </Td>
+        <Td>
+          <TestServerAction unprotected startTransition={startTransition} setComponent={setComponent} behaviour="error" />
+        </Td>
+        <Td>
+          <TestServerAction unprotected startTransition={startTransition} setComponent={setComponent} behaviour="redirect" />
+        </Td>
+        <Td>
+          <TestServerAction unprotected startTransition={startTransition} setComponent={setComponent} behaviour="allow" />
+        </Td>
+      </tr>
+      <tr>
+        <th>Unprotected API route</th>
+        <Td>
+          <TestLink href="/auth/protected/unprotected/api" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/unprotected/api?auth-behaviour=response" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/unprotected/api?auth-behaviour=response-throw" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/unprotected/api?auth-behaviour=deny" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/unprotected/api?auth-behaviour=deny-throw" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/unprotected/api?auth-behaviour=error" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/unprotected/api?auth-behaviour=redirect" />
+        </Td>
+        <Td>
+          <TestLink href="/auth/protected/unprotected/api?auth-behaviour=allow" />
+        </Td>
+      </tr>
+    </table>
+
+    {isPending || component ? (<><h1 className="mt-10 text-3xl font-black tracking-tighter">Server action returned component</h1><div className="mt-3 w-full border border-black rounded-sm">
+      {isPending
+        ? "Component is loading..."
+        : component}
+    </div></>) : null}
+
+    <h1 className="mt-10 text-3xl font-black tracking-tighter">Page &amp; API route test iframe</h1>
+    <iframe name="page-test" className="mt-3 w-full border border-black rounded-sm" height={300}></iframe>
+  </div>
+}
+

--- a/examples/kitchen-sink/app/pages/auth/cookie.ts
+++ b/examples/kitchen-sink/app/pages/auth/cookie.ts
@@ -1,0 +1,16 @@
+"use server";
+
+import cookies from "@twofold/framework/cookies";
+import { redirect } from "@twofold/framework/redirect";
+
+export async function setCookie() {
+  "use server";
+  cookies.set("allow-access", "true");
+  redirect("/auth");
+}
+
+export async function clearCookie() {
+  "use server";
+  cookies.destroy("allow-access");
+  redirect("/auth");
+}

--- a/examples/kitchen-sink/app/pages/auth/index.page.tsx
+++ b/examples/kitchen-sink/app/pages/auth/index.page.tsx
@@ -1,0 +1,8 @@
+import cookies from "@twofold/framework/cookies";
+import Control from "./Control";
+
+export default function Page() {
+  const allowIfCookieSetWillPass = cookies.get("allow-access") === 'true';
+
+  return <Control allowIfCookieSetWillPass={allowIfCookieSetWillPass} />;
+}

--- a/examples/kitchen-sink/app/pages/auth/protected/action/protectedAction.tsx
+++ b/examples/kitchen-sink/app/pages/auth/protected/action/protectedAction.tsx
@@ -1,0 +1,10 @@
+"use server";
+
+import { behaveBasedOnFormData } from "@/app/auth";
+import { AuthPolicyArray } from "@twofold/framework/auth";
+
+export const auth: AuthPolicyArray = [behaveBasedOnFormData];
+
+export default async function action(formData: FormData) {
+  return <div>This is a server component returned by a server action. It will only be returned if the authentication policies pass. The behaviour was '{formData.get("behaviour")?.toString()}'.</div>;
+}

--- a/examples/kitchen-sink/app/pages/auth/protected/api/index.api.ts
+++ b/examples/kitchen-sink/app/pages/auth/protected/api/index.api.ts
@@ -1,0 +1,14 @@
+import { behaveBasedOnQueryString } from "@/app/auth";
+import { AuthPolicyArray } from "@twofold/framework/auth";
+
+export const auth: AuthPolicyArray = [behaveBasedOnQueryString];
+
+export function GET() {
+  return new Response(JSON.stringify({
+    message: "This is an API route that only runs if the authentication policies pass."
+  }), {
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}

--- a/examples/kitchen-sink/app/pages/auth/protected/layout.tsx
+++ b/examples/kitchen-sink/app/pages/auth/protected/layout.tsx
@@ -1,0 +1,4 @@
+import { allowIfCookieSet } from "@/app/auth";
+import { AuthPolicyArray } from "@twofold/framework/auth";
+
+export const auth: AuthPolicyArray = [allowIfCookieSet];

--- a/examples/kitchen-sink/app/pages/auth/protected/page/index.page.tsx
+++ b/examples/kitchen-sink/app/pages/auth/protected/page/index.page.tsx
@@ -1,0 +1,8 @@
+import { behaveBasedOnQueryString } from "@/app/auth";
+import { AuthPolicyArray } from "@twofold/framework/auth";
+
+export const auth: AuthPolicyArray = [behaveBasedOnQueryString];
+
+export default function Page() {
+  return <div>This message won't show unless the authentication policies allow it.</div>;
+}

--- a/examples/kitchen-sink/app/pages/auth/protected/unprotected/action/unprotectedAction.tsx
+++ b/examples/kitchen-sink/app/pages/auth/protected/unprotected/action/unprotectedAction.tsx
@@ -1,0 +1,9 @@
+"use server";
+
+import { AuthPolicyArray, reset } from "@twofold/framework/auth";
+
+export const auth: AuthPolicyArray = [reset];
+
+export default async function action(formData: FormData) {
+  return <div>This is a server component returned by a server action. It is running on an action that uses 'reset' to allow access regardless of the parent routes. The behaviour was '{formData.get("behaviour")?.toString()}'.</div>;
+}

--- a/examples/kitchen-sink/app/pages/auth/protected/unprotected/api/index.api.ts
+++ b/examples/kitchen-sink/app/pages/auth/protected/unprotected/api/index.api.ts
@@ -1,0 +1,13 @@
+import { AuthPolicyArray, reset } from "@twofold/framework/auth";
+
+export const auth: AuthPolicyArray = [reset];
+
+export function GET() {
+  return new Response(JSON.stringify({
+    message: "This is an API route that uses 'reset' to skip the authentication policies of the parent routes."
+  }), {
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}

--- a/examples/kitchen-sink/app/pages/auth/protected/unprotected/page/index.page.tsx
+++ b/examples/kitchen-sink/app/pages/auth/protected/unprotected/page/index.page.tsx
@@ -1,0 +1,7 @@
+import { AuthPolicyArray, reset } from "@twofold/framework/auth";
+
+export const auth: AuthPolicyArray = [reset];
+
+export default function Page() {
+  return <div>This message should always show since this page resets the authentication policies of the parent routes.</div>;
+}

--- a/examples/kitchen-sink/app/pages/nav.tsx
+++ b/examples/kitchen-sink/app/pages/nav.tsx
@@ -412,6 +412,14 @@ export default function Nav() {
                       />
                     </ExampleGroup>
 
+                    <ExampleGroup name="Auth" path="/auth">
+                      <ExampleLink
+                        title="Auth"
+                        description="Demonstrates auth policies."
+                        href="/auth"
+                      />
+                    </ExampleGroup>
+
                     <NavigationMenu.Indicator className="-right-5 z-10 flex h-6 items-center justify-center overflow-hidden">
                       <div className="relative -left-[70%] flex h-6 w-6 rotate-45 items-center justify-center rounded-[3px] bg-gray-100">
                         <div className="relative h-4 w-4 rounded-[1.5px] bg-white" />

--- a/package.json
+++ b/package.json
@@ -11,5 +11,6 @@
   "devDependencies": {
     "@changesets/cli": "^2.29.7",
     "typescript": "catalog:"
-  }
+  },
+  "packageManager": "pnpm@9.15.2+sha512.93e57b0126f0df74ce6bff29680394c0ba54ec47246b9cf321f0121d8d9bb03f750a705f24edc3c1180853afd7c2c3b94196d0a3d53d3e069d9e2793ef11f321"
 }

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -29,6 +29,7 @@
     "./use-router": "./src/client/hooks/use-router.ts",
     "./use-optimistic-route": "./src/client/hooks/use-optimistic-route.ts",
     "./cookies": "./src/client/http/cookies.ts",
+    "./auth": "./src/client/http/auth.ts",
     "./not-found": "./src/client/http/not-found.ts",
     "./unauthorized": "./src/client/http/unauthorized.ts",
     "./redirect": "./src/client/http/redirect.ts",

--- a/packages/framework/src/backend/auth/auth.ts
+++ b/packages/framework/src/backend/auth/auth.ts
@@ -1,0 +1,88 @@
+/**
+ * The properties about the request provided when evaluating an authentication policy.
+ */
+export type AuthPolicyProps = {
+  type: "page";
+  request: Request;
+  routeParams: Record<string, string | undefined>;
+} | {
+  type: "action";
+  request: Request;
+} | {
+  type: "api";
+  request: Request;
+};
+
+/**
+ * An authentication policy.
+ */
+export type AuthPolicy = ((props: AuthPolicyProps) => Promise<AuthPolicyResult>);
+
+/**
+ * An array of authentication policies (and optionally 'reset').
+ */
+export type AuthPolicyArray = ({ __reset: true } | AuthPolicy)[];
+
+/**
+ * This entry in an authentication policy array will cause any authentication policies prior to it to be discarded. By default, authentication policy arrays inherit the authentication policies of the parent route.
+ */
+export const reset: { __reset: true } = { __reset: true };
+
+/**
+ * The result returned by an authentication policy.
+ */
+export type AuthPolicyResult = { __allow: boolean, __message?: string, __error?: any, __response?: Response };
+
+/**
+ * Construct an authentication policy result that allows execution to continue.
+ * 
+ * @returns The authentication policy result.
+ */
+export function allow(): AuthPolicyResult {
+  return { __allow: true };
+}
+
+/**
+ * Construct an authentication policy result that denies access to the route with a message.
+ * 
+ * @param message The error message to return to the user.
+ * @returns The authentication policy result.
+ */
+export function deny(message: string) {
+  return { __allow: false, __message: message };
+}
+
+/**
+ * Construct an authentication policy result that stops execution and returns the specified response immediately.
+ * 
+ * @param response The response to return to the user.
+ * @returns The authentication policy result.
+ */
+export function response(response: Response) {
+  return { __allow: false, __response: response };
+}
+
+/**
+ * Evaluates an authentication policy and returns an authentication policy result, catching any errors thrown.
+ * 
+ * @param policy The authentication policy to evaluate.
+ * @param props The properties about the request provided to the authentication policy.
+ * @returns The authentication policy result.
+ */
+export async function evaluatePolicy(policy: AuthPolicy, props: AuthPolicyProps): Promise<AuthPolicyResult> {
+  try {
+    const result = await policy(props);
+    if (result === undefined || result === null) {
+      return deny("policy did not return valid result");
+    }
+    return result;
+  } catch (err) {
+    if (err instanceof Response) {
+      return response(err);
+    } else if (typeof err === 'string') {
+      return deny(err);
+    } else {
+      return { __allow: false, __message: err?.toString() ?? "", __error: err }
+    }
+  }
+}

--- a/packages/framework/src/backend/build/builders/rsc-builder.ts
+++ b/packages/framework/src/backend/build/builders/rsc-builder.ts
@@ -27,14 +27,441 @@ import { ErrorTemplate } from "../rsc/error-template.js";
 import { Generic } from "../rsc/generic.js";
 import { CatchBoundary } from "../rsc/catch-boundary.js";
 import { invariant } from "../../utils/invariant.js";
+import { Node } from "../rsc/tree-node.js"
+import { CompiledServerAction } from "../rsc/compiled-server-action.js";
 
-export type CompiledAction = {
-  id: string;
-  moduleId: string;
-  path: string;
-  hash: string;
-  export: string;
-};
+interface ApplicationTreeProps {
+  metafile: Metafile | undefined;
+  serverActionMap: Map<string, CompiledServerAction>;
+  routeStackPlaceholder: Generic;
+  compiledPathForEntry: (entryPath: string) => string;
+}
+
+/**
+ * We need to ensure that all of the constructed values used by the application
+ * are the values that exist in the root tree, otherwise objects that would be
+ * constructed dynamically would not have access to 'parent'.
+ * 
+ * This did not matter in the past for API routes, but now that we use the tree
+ * to lookup authentication policies, we want to make sure nothing ever constructs
+ * something for routing without the appropriate parent context set.
+ */
+class ApplicationTree {
+  #pages: Page[];
+  #layouts: Layout[];
+  #apiEndpoints: API[];
+  #errorTemplates: ErrorTemplate[];
+  #catchBoundaries: CatchBoundary[];
+  #outerRootWrapper: Wrapper;
+  #serverActionMap: Map<string, CompiledServerAction>;
+  #unauthorizedPage: Page;
+  #notFoundPage: Page;
+  #root: Layout;
+
+  constructor(props: ApplicationTreeProps) {
+    this.#pages = ApplicationTree.#constructPages(props.metafile);
+    this.#layouts = ApplicationTree.#constructLayouts(props.metafile, props.routeStackPlaceholder);
+    this.#apiEndpoints = ApplicationTree.#constructApiEndpoints(props.metafile);
+    this.#errorTemplates = ApplicationTree.#constructErrorTemplates(props.metafile);
+    this.#catchBoundaries = ApplicationTree.#constructCatchBoundaries(props.metafile, props.routeStackPlaceholder, props.compiledPathForEntry, this.#errorTemplates)
+    this.#outerRootWrapper = ApplicationTree.#constructOuterRootWrapper(props.compiledPathForEntry);
+    this.#serverActionMap = props.serverActionMap;
+    this.#unauthorizedPage = ApplicationTree.#constructUnauthorizedPage(props.metafile);
+    this.#notFoundPage = ApplicationTree.#constructNotFoundPage(props.metafile);
+    this.#root = this.#constructRoot();
+  }
+  
+  findPageForPath(path: string) {
+    return this.#root.tree.findPageForPath(path);
+  }
+
+  get root() {
+    return this.#root;
+  }
+
+  get pages() {
+    return this.#pages;
+  }
+
+  get layouts() {
+    return this.#layouts;
+  }
+
+  get apiEndpoints() {
+    return this.#apiEndpoints;
+  }
+
+  get notFoundPage() {
+    return this.#notFoundPage;
+  }
+
+  get outerRootWrapper() {
+    return this.#outerRootWrapper;
+  }
+
+  get errorTemplates() {
+    return this.#errorTemplates;
+  }
+
+  get catchBoundaries() {
+    return this.#catchBoundaries;
+  }
+
+  static #constructPages(metafile: Metafile | undefined) {
+    if (!metafile) {
+      return [];
+    }
+
+    let outputs = metafile.outputs;
+    let cwd = process.cwd();
+    let baseUrl = pathToFileURL(`${cwd}/`);
+    let prefix = "app/pages/";
+    let pageSuffix = ".page.tsx";
+
+    let cssUrl = new URL("./rsc/css/", appCompiledDir);
+    let cssPath = fileURLToPath(cssUrl);
+    let cssPrefix = cssPath.slice(process.cwd().length + 1);
+
+    let keys = Object.keys(outputs);
+    return keys
+      .filter((key) => {
+        let entryPoint = outputs[key]?.entryPoint;
+        return (
+          entryPoint &&
+          entryPoint.startsWith(prefix) &&
+          entryPoint.endsWith(pageSuffix)
+        );
+      })
+      .map((key) => {
+        let output = outputs[key];
+        if (!output) {
+          throw new Error("No output found for key");
+        }
+
+        let entryPoint = output.entryPoint;
+        if (!entryPoint) {
+          throw new Error("No entry point");
+        }
+
+        let path = entryPoint.slice(prefix.length).slice(0, -pageSuffix.length);
+        if (path === "index" || path.endsWith("/index")) {
+          path = path.slice(0, -6);
+        }
+        path = `/${path}`;
+
+        return new Page({
+          path,
+          css: output.cssBundle
+            ? output.cssBundle.slice(cssPrefix.length)
+            : undefined,
+          fileUrl: new URL(key, baseUrl),
+        });
+      });
+  }
+
+  static #constructLayouts(metafile: Metafile | undefined, routeStackPlaceholder: Generic) {
+    if (!metafile) {
+      return [];
+    }
+
+    let outputs = metafile.outputs;
+    let cwd = process.cwd();
+    let baseUrl = pathToFileURL(`${cwd}/`);
+    let prefix = "app/pages/";
+    let layoutSuffix = "/layout.tsx";
+
+    let cssUrl = new URL("./rsc/css/", appCompiledDir);
+    let cssPath = fileURLToPath(cssUrl);
+    let cssPrefix = cssPath.slice(process.cwd().length + 1);
+
+    let keys = Object.keys(outputs);
+
+    return keys
+      .filter((key) => {
+        let entryPoint = outputs[key]?.entryPoint;
+        return (
+          entryPoint &&
+          entryPoint.startsWith(prefix) &&
+          entryPoint.endsWith(layoutSuffix)
+        );
+      })
+      .map((key) => {
+        let output = outputs[key];
+        if (!output) {
+          throw new Error("No output found for key");
+        }
+
+        let entryPoint = output.entryPoint;
+        if (!entryPoint) {
+          throw new Error("No entry point");
+        }
+
+        let path = entryPoint
+          .slice(prefix.length)
+          .slice(0, -layoutSuffix.length);
+
+        return new Layout({
+          path: `/${path}`,
+          css: output.cssBundle
+            ? output.cssBundle.slice(cssPrefix.length)
+            : undefined,
+          fileUrl: new URL(key, baseUrl),
+          routeStackPlaceholder,
+        });
+      });
+  }
+
+  static #constructApiEndpoints(metafile: Metafile | undefined) {
+    if (!metafile) {
+      return [];
+    }
+
+    let outputs = metafile.outputs;
+    let cwd = process.cwd();
+    let baseUrl = pathToFileURL(`${cwd}/`);
+    let prefix = "app/pages/";
+    let apiSuffix = /\.api\.tsx?$/;
+
+    let keys = Object.keys(outputs);
+    return keys
+      .filter((key) => {
+        let entryPoint = outputs[key]?.entryPoint;
+        return (
+          entryPoint &&
+          entryPoint.startsWith(prefix) &&
+          apiSuffix.test(entryPoint)
+        );
+      })
+      .map((key) => {
+        let output = outputs[key];
+        if (!output) {
+          throw new Error("No output found for key");
+        }
+
+        let entryPoint = output.entryPoint;
+        if (!entryPoint) {
+          throw new Error("No entry point");
+        }
+
+        let suffixMatch = apiSuffix.exec(entryPoint);
+        if (!suffixMatch) {
+          throw new Error("No suffix match");
+        }
+
+        // either api.ts or api.tsx
+        let suffix = suffixMatch[0];
+
+        let path = entryPoint.slice(prefix.length).slice(0, -suffix.length);
+        if (path === "index" || path.endsWith("/index")) {
+          path = path.slice(0, -6);
+        }
+        path = `/${path}`;
+
+        return new API({
+          path,
+          fileUrl: new URL(key, baseUrl),
+        });
+      });
+  }
+
+  static #constructErrorTemplates(metafile: Metafile | undefined) {
+    if (!metafile) {
+      return [];
+    }
+
+    let outputs = metafile.outputs;
+    let cwd = process.cwd();
+    let baseUrl = pathToFileURL(`${cwd}/`);
+    let prefix = "app/pages/";
+    let errorSuffix = ".error.tsx";
+
+    let keys = Object.keys(outputs);
+    let templates = keys
+      .filter((key) => {
+        let entryPoint = outputs[key]?.entryPoint;
+        return (
+          entryPoint &&
+          entryPoint.startsWith(prefix) &&
+          entryPoint.endsWith(errorSuffix)
+        );
+      })
+      .map((key) => {
+        let output = outputs[key];
+        if (!output) {
+          throw new Error("No output found for key");
+        }
+
+        let entryPoint = output.entryPoint;
+        if (!entryPoint) {
+          throw new Error("No entry point");
+        }
+
+        let path = `/${entryPoint
+          .slice(prefix.length)
+          .slice(0, -errorSuffix.length)}`;
+
+        let tag = path.split("/").at(-1) ?? "unknown";
+
+        return new ErrorTemplate({
+          tag,
+          path,
+          fileUrl: new URL(key, baseUrl),
+        });
+      });
+
+    // if there is no root level unauthorized template we will add the default
+    if (!templates.some((t) => t.tag === "unauthorized" && t.path === "/")) {
+      let defaultUnauthorizedPath = getCompiledEntrypoint(
+        srcPaths.framework.errorTemplates.unauthorized,
+        metafile,
+      );
+
+      templates.push(
+        new ErrorTemplate({
+          tag: "unauthorized",
+          path: "/",
+          fileUrl: pathToFileURL(defaultUnauthorizedPath),
+        }),
+      );
+    }
+
+    // if there is no root level not found template we will add the default
+    if (!templates.some((t) => t.tag === "not-found" && t.path === "/")) {
+      let defaultNotFoundPath = getCompiledEntrypoint(
+        srcPaths.framework.errorTemplates.notFound,
+        metafile,
+      );
+
+      templates.push(
+        new ErrorTemplate({
+          tag: "not-found",
+          path: "/",
+          fileUrl: pathToFileURL(defaultNotFoundPath),
+        }),
+      );
+    }
+
+    return templates;
+  }
+
+  static #constructCatchBoundaries(metafile: Metafile | undefined, routeStackPlaceholder: Generic, compiledPathForEntry: (entryPath: string) => string, errorTemplates: ErrorTemplate[]) {
+    let catchBoundaryPath = compiledPathForEntry(
+      srcPaths.framework.catchBoundary,
+    );
+    let catchBoundaryUrl = pathToFileURL(catchBoundaryPath);
+
+    let catchBoundaryMap = new Map<string, CatchBoundary>();
+
+    // always have a root level catch boundary
+    catchBoundaryMap.set(
+      "/",
+      new CatchBoundary({
+        path: "/",
+        fileUrl: catchBoundaryUrl,
+        routeStackPlaceholder,
+      }),
+    );
+
+    for (let errorTemplate of errorTemplates) {
+      let path =
+        errorTemplate.path === "/"
+          ? "/"
+          : "/" +
+            errorTemplate.path
+              .split("/")
+              .filter(Boolean)
+              .slice(0, -1)
+              .join("/");
+
+      let catchBoundary = catchBoundaryMap.get(path);
+
+      if (!catchBoundary) {
+        catchBoundary = new CatchBoundary({
+          path,
+          fileUrl: catchBoundaryUrl,
+          routeStackPlaceholder,
+        });
+
+        catchBoundaryMap.set(path, catchBoundary);
+      }
+    }
+
+    return [...catchBoundaryMap.values()];
+  }
+
+  static #constructOuterRootWrapper(compiledPathForEntry: (entryPath: string) => string) {
+    let outputFilePath = compiledPathForEntry(
+      srcPaths.framework.outerRootWrapper,
+    );
+    let outputFileUrl = pathToFileURL(outputFilePath);
+
+    let wrapper = new Wrapper({
+      path: "/",
+      fileUrl: outputFileUrl,
+    });
+
+    return wrapper;
+  }
+
+  static #constructUnauthorizedPage(metafile: Metafile | undefined) {
+    invariant(metafile, "Could not find metafile");
+
+    let entryPoint = srcPaths.framework.pages.unauthorized;
+    let outputFile = getCompiledEntrypoint(entryPoint, metafile);
+
+    let page = new Page({
+      path: "/__tf/errors/unauthorized",
+      fileUrl: pathToFileURL(outputFile),
+    });
+
+    return page;
+  }
+
+  static #constructNotFoundPage(metafile: Metafile | undefined) {
+    invariant(metafile, "Could not find metafile");
+
+    let entryPoint = srcPaths.framework.pages.notFound;
+    let outputFile = getCompiledEntrypoint(entryPoint, metafile);
+
+    let page = new Page({
+      path: "/__tf/errors/not-found",
+      fileUrl: pathToFileURL(outputFile),
+    });
+
+    return page;
+  }
+
+  #constructRoot() {
+    let pages = this.#pages;
+    let layouts = this.#layouts;
+    let apiEndpoints = this.#apiEndpoints;
+    let serverActions = this.#serverActionMap.values();
+    let errorTemplates = this.#errorTemplates;
+    let catchBoundaries = this.#catchBoundaries;
+    let outerRootWrapper = this.#outerRootWrapper;
+
+    let root = layouts.find((layout) => layout.path === "/");
+    let otherLayouts = layouts.filter((layout) => layout.path !== "/");
+
+    if (!root) {
+      throw new Error("No root layout");
+    }
+
+    otherLayouts.forEach((layout) => root.addChild(layout));
+    catchBoundaries.forEach((catchBoundary) => root.addChild(catchBoundary));
+    pages.forEach((page) => root.addChild(page));
+    apiEndpoints.forEach((apiEndpoint) => root.addChild(apiEndpoint));
+    serverActions.forEach((serverAction) => root.addChild(serverAction));
+    errorTemplates.forEach((errorTemplate) => root.addChild(errorTemplate));
+
+    root.addChild(this.#unauthorizedPage);
+    root.addChild(this.#notFoundPage);
+
+    root.addWrapper(outerRootWrapper);
+
+    return root;
+  }
+}
 
 export class RSCBuilder extends Builder {
   readonly name = "rsc";
@@ -42,9 +469,10 @@ export class RSCBuilder extends Builder {
   #metafile?: Metafile | undefined;
   #entriesBuilder: EntriesBuilder;
   #build: Build;
-  #serverActionMap = new Map<string, CompiledAction>();
+  #serverActionMap = new Map<string, CompiledServerAction>();
   #imagesMap = new Map<string, Image>();
   #fontsMap = new Map<string, Font>();
+  #cachedApplicationTree: ApplicationTree | undefined = undefined;
 
   constructor({
     entriesBuilder,
@@ -74,6 +502,19 @@ export class RSCBuilder extends Builder {
     return this.#entriesBuilder;
   }
 
+  get #applicationTree() {
+    if (this.#cachedApplicationTree !== undefined) {
+      return this.#cachedApplicationTree;
+    }
+    this.#cachedApplicationTree = new ApplicationTree({
+      metafile: this.#metafile,
+      serverActionMap: this.#serverActionMap,
+      routeStackPlaceholder: this.routeStackPlaceholder,
+      compiledPathForEntry: (path) => this.compiledPathForEntry(path),
+    });
+    return this.#cachedApplicationTree;
+  }
+
   async setup() {}
 
   async build() {
@@ -81,6 +522,9 @@ export class RSCBuilder extends Builder {
 
     let hasMiddleware = await this.hasMiddleware();
     let middlewareEntry = hasMiddleware ? [srcPaths.app.globalMiddleware] : [];
+
+    let hasRootAuth = await this.hasRootAuth();
+    let rootAuthEntry = hasRootAuth ? [srcPaths.app.rootAuth] : [];
 
     let notFoundTemplateEntry = await this.notFoundTemplateSrcPath();
     let unauthorizedTemplateEntry =
@@ -114,6 +558,7 @@ export class RSCBuilder extends Builder {
           "./app/pages/**/*.api.ts",
           "./app/pages/**/*.api.tsx",
           ...middlewareEntry,
+          ...rootAuthEntry,
           ...serverActionEntries,
           notFoundTemplateEntry,
           unauthorizedTemplateEntry,
@@ -235,7 +680,7 @@ export class RSCBuilder extends Builder {
   serialize() {
     return {
       metafile: this.#metafile,
-      serverActionMap: Object.fromEntries(this.#serverActionMap.entries()),
+      serverActionMap: Object.fromEntries(this.#serverActionMap.entries().map(kv => [kv[0], kv[1].serialize()])),
       imagesMap: Object.fromEntries(this.#imagesMap.entries()),
       fontsMap: Object.fromEntries(this.#fontsMap.entries()),
     };
@@ -243,31 +688,37 @@ export class RSCBuilder extends Builder {
 
   load(data: any) {
     this.#metafile = data.metafile;
-    this.#serverActionMap = new Map(Object.entries(data.serverActionMap));
+    this.#serverActionMap = new Map(Object.entries(data.serverActionMap).map(kv => [kv[0], new CompiledServerAction(kv[1] as any)]));
     this.#imagesMap = new Map(Object.entries(data.imagesMap));
     this.#fontsMap = new Map(Object.entries(data.fontsMap));
+    this.#cachedApplicationTree = undefined;
   }
 
   async warm() {
-    let loadLayouts = this.layouts.map((l) => l.preload());
-    let loadPages = this.pages.map((p) => p.preload());
-    let loadNotFound = this.notFoundPage.preload();
-    let loadOuterRootWrapper = this.outerRootWrapper.preload();
-    let apiEndpoints = this.apiEndpoints.map((api) => api.preload());
-    let errorTemplates = this.errorTemplates.map((errorTemplate) =>
+    let loadLayouts = this.#applicationTree.layouts.map((l) => l.preload());
+    let loadPages = this.#applicationTree.pages.map((p) => p.preload());
+    let loadNotFound = this.#applicationTree.notFoundPage.preload();
+    let loadOuterRootWrapper = this.#applicationTree.outerRootWrapper.preload();
+    let apiEndpoints = this.#applicationTree.apiEndpoints.map((api) => api.preload());
+    let errorTemplates = this.#applicationTree.errorTemplates.map((errorTemplate) =>
       errorTemplate.preload(),
     );
-    let catchBoundaries = this.catchBoundaries.map((catchBoundary) =>
+    let catchBoundaries = this.#applicationTree.catchBoundaries.map((catchBoundary) =>
       catchBoundary.preload(),
     );
 
     let loadServerActions = this.#serverActionMap
       .values()
-      .map((a) => import(pathToFileURL(a.path).href));
+      .map((a) => a.preload());
 
     let hasMiddleware = await this.hasMiddleware();
     let loadGlobalMiddleware = hasMiddleware
       ? import(pathToFileURL(this.middlewarePath).href)
+      : Promise.resolve();
+
+    let hasRootAuth = await this.hasRootAuth();
+    let loadRootAuth = hasRootAuth
+      ? import(pathToFileURL(this.rootAuthPath).href)
       : Promise.resolve();
 
     let loadRouteStackPlaceholder = import(
@@ -284,6 +735,7 @@ export class RSCBuilder extends Builder {
       ...apiEndpoints,
       ...loadServerActions,
       loadGlobalMiddleware,
+      loadRootAuth,
       loadRouteStackPlaceholder,
     ];
 
@@ -298,6 +750,14 @@ export class RSCBuilder extends Builder {
     }
 
     return Object.keys(metafile.outputs);
+  }
+
+  hasRootAuth() {
+    return fileExists(srcPaths.app.rootAuth);
+  }
+
+  get rootAuthPath() {
+    return this.compiledPathForEntry(srcPaths.app.rootAuth);
   }
 
   hasMiddleware() {
@@ -322,280 +782,16 @@ export class RSCBuilder extends Builder {
       : srcPaths.framework.errorTemplates.unauthorized;
   }
 
-  private get notFoundPage() {
-    let metafile = this.#metafile;
-    invariant(metafile, "Could not find metafile");
-
-    let entryPoint = srcPaths.framework.pages.notFound;
-    let outputFile = getCompiledEntrypoint(entryPoint, metafile);
-
-    let page = new Page({
-      path: "/__tf/errors/not-found",
-      fileUrl: pathToFileURL(outputFile),
-    });
-
-    return page;
-  }
-
-  private get unauthorizedPage() {
-    let metafile = this.#metafile;
-    invariant(metafile, "Could not find metafile");
-
-    let entryPoint = srcPaths.framework.pages.unauthorized;
-    let outputFile = getCompiledEntrypoint(entryPoint, metafile);
-
-    let page = new Page({
-      path: "/__tf/errors/unauthorized",
-      fileUrl: pathToFileURL(outputFile),
-    });
-
-    return page;
-  }
-
   get pages() {
-    let metafile = this.#metafile;
-
-    if (!metafile) {
-      return [];
-    }
-
-    let outputs = metafile.outputs;
-    let cwd = process.cwd();
-    let baseUrl = pathToFileURL(`${cwd}/`);
-    let prefix = "app/pages/";
-    let pageSuffix = ".page.tsx";
-
-    let cssUrl = new URL("./rsc/css/", appCompiledDir);
-    let cssPath = fileURLToPath(cssUrl);
-    let cssPrefix = cssPath.slice(process.cwd().length + 1);
-
-    let keys = Object.keys(outputs);
-    return keys
-      .filter((key) => {
-        let entryPoint = outputs[key]?.entryPoint;
-        return (
-          entryPoint &&
-          entryPoint.startsWith(prefix) &&
-          entryPoint.endsWith(pageSuffix)
-        );
-      })
-      .map((key) => {
-        let output = outputs[key];
-        if (!output) {
-          throw new Error("No output found for key");
-        }
-
-        let entryPoint = output.entryPoint;
-        if (!entryPoint) {
-          throw new Error("No entry point");
-        }
-
-        let path = entryPoint.slice(prefix.length).slice(0, -pageSuffix.length);
-        if (path === "index" || path.endsWith("/index")) {
-          path = path.slice(0, -6);
-        }
-        path = `/${path}`;
-
-        return new Page({
-          path,
-          css: output.cssBundle
-            ? output.cssBundle.slice(cssPrefix.length)
-            : undefined,
-          fileUrl: new URL(key, baseUrl),
-        });
-      });
-  }
-
-  private get errorTemplates() {
-    let metafile = this.#metafile;
-    if (!metafile) {
-      return [];
-    }
-
-    let outputs = metafile.outputs;
-    let cwd = process.cwd();
-    let baseUrl = pathToFileURL(`${cwd}/`);
-    let prefix = "app/pages/";
-    let errorSuffix = ".error.tsx";
-
-    let keys = Object.keys(outputs);
-    let templates = keys
-      .filter((key) => {
-        let entryPoint = outputs[key]?.entryPoint;
-        return (
-          entryPoint &&
-          entryPoint.startsWith(prefix) &&
-          entryPoint.endsWith(errorSuffix)
-        );
-      })
-      .map((key) => {
-        let output = outputs[key];
-        if (!output) {
-          throw new Error("No output found for key");
-        }
-
-        let entryPoint = output.entryPoint;
-        if (!entryPoint) {
-          throw new Error("No entry point");
-        }
-
-        let path = `/${entryPoint
-          .slice(prefix.length)
-          .slice(0, -errorSuffix.length)}`;
-
-        let tag = path.split("/").at(-1) ?? "unknown";
-
-        return new ErrorTemplate({
-          tag,
-          path,
-          fileUrl: new URL(key, baseUrl),
-        });
-      });
-
-    // if there is no root level unauthorized template we will add the default
-    if (!templates.some((t) => t.tag === "unauthorized" && t.path === "/")) {
-      let defaultUnauthorizedPath = getCompiledEntrypoint(
-        srcPaths.framework.errorTemplates.unauthorized,
-        metafile,
-      );
-
-      templates.push(
-        new ErrorTemplate({
-          tag: "unauthorized",
-          path: "/",
-          fileUrl: pathToFileURL(defaultUnauthorizedPath),
-        }),
-      );
-    }
-
-    // if there is no root level not found template we will add the default
-    if (!templates.some((t) => t.tag === "not-found" && t.path === "/")) {
-      let defaultNotFoundPath = getCompiledEntrypoint(
-        srcPaths.framework.errorTemplates.notFound,
-        metafile,
-      );
-
-      templates.push(
-        new ErrorTemplate({
-          tag: "not-found",
-          path: "/",
-          fileUrl: pathToFileURL(defaultNotFoundPath),
-        }),
-      );
-    }
-
-    return templates;
+    return this.#applicationTree.pages;
   }
 
   get layouts() {
-    let metafile = this.#metafile;
-
-    if (!metafile) {
-      return [];
-    }
-
-    let outputs = metafile.outputs;
-    let cwd = process.cwd();
-    let baseUrl = pathToFileURL(`${cwd}/`);
-    let prefix = "app/pages/";
-    let layoutSuffix = "/layout.tsx";
-
-    let cssUrl = new URL("./rsc/css/", appCompiledDir);
-    let cssPath = fileURLToPath(cssUrl);
-    let cssPrefix = cssPath.slice(process.cwd().length + 1);
-
-    let keys = Object.keys(outputs);
-
-    let routeStackPlaceholder = this.routeStackPlaceholder;
-
-    return keys
-      .filter((key) => {
-        let entryPoint = outputs[key]?.entryPoint;
-        return (
-          entryPoint &&
-          entryPoint.startsWith(prefix) &&
-          entryPoint.endsWith(layoutSuffix)
-        );
-      })
-      .map((key) => {
-        let output = outputs[key];
-        if (!output) {
-          throw new Error("No output found for key");
-        }
-
-        let entryPoint = output.entryPoint;
-        if (!entryPoint) {
-          throw new Error("No entry point");
-        }
-
-        let path = entryPoint
-          .slice(prefix.length)
-          .slice(0, -layoutSuffix.length);
-
-        return new Layout({
-          path: `/${path}`,
-          css: output.cssBundle
-            ? output.cssBundle.slice(cssPrefix.length)
-            : undefined,
-          fileUrl: new URL(key, baseUrl),
-          routeStackPlaceholder,
-        });
-      });
+    return this.#applicationTree.layouts;
   }
 
   get apiEndpoints() {
-    let metafile = this.#metafile;
-
-    if (!metafile) {
-      return [];
-    }
-
-    let outputs = metafile.outputs;
-    let cwd = process.cwd();
-    let baseUrl = pathToFileURL(`${cwd}/`);
-    let prefix = "app/pages/";
-    let apiSuffix = /\.api\.tsx?$/;
-
-    let keys = Object.keys(outputs);
-    return keys
-      .filter((key) => {
-        let entryPoint = outputs[key]?.entryPoint;
-        return (
-          entryPoint &&
-          entryPoint.startsWith(prefix) &&
-          apiSuffix.test(entryPoint)
-        );
-      })
-      .map((key) => {
-        let output = outputs[key];
-        if (!output) {
-          throw new Error("No output found for key");
-        }
-
-        let entryPoint = output.entryPoint;
-        if (!entryPoint) {
-          throw new Error("No entry point");
-        }
-
-        let suffixMatch = apiSuffix.exec(entryPoint);
-        if (!suffixMatch) {
-          throw new Error("No suffix match");
-        }
-
-        // either api.ts or api.tsx
-        let suffix = suffixMatch[0];
-
-        let path = entryPoint.slice(prefix.length).slice(0, -suffix.length);
-        if (path === "index" || path.endsWith("/index")) {
-          path = path.slice(0, -6);
-        }
-        path = `/${path}`;
-
-        return new API({
-          path,
-          fileUrl: new URL(key, baseUrl),
-        });
-      });
+    return this.#applicationTree.apiEndpoints;
   }
 
   private compiledPathForEntry(entryPath: string) {
@@ -613,20 +809,6 @@ export class RSCBuilder extends Builder {
     return outputFilePath;
   }
 
-  private get outerRootWrapper() {
-    let outputFilePath = this.compiledPathForEntry(
-      srcPaths.framework.outerRootWrapper,
-    );
-    let outputFileUrl = pathToFileURL(outputFilePath);
-
-    let wrapper = new Wrapper({
-      path: "/",
-      fileUrl: outputFileUrl,
-    });
-
-    return wrapper;
-  }
-
   get routeStackPlaceholderPath() {
     return this.compiledPathForEntry(srcPaths.framework.routeStackPlaceholder);
   }
@@ -636,53 +818,6 @@ export class RSCBuilder extends Builder {
     let placeholderUrl = pathToFileURL(placeholderPath);
     let placeholder = new Generic({ fileUrl: placeholderUrl });
     return placeholder;
-  }
-
-  private get catchBoundaries() {
-    let routeStackPlaceholder = this.routeStackPlaceholder;
-    let catchBoundaryPath = this.compiledPathForEntry(
-      srcPaths.framework.catchBoundary,
-    );
-    let catchBoundaryUrl = pathToFileURL(catchBoundaryPath);
-
-    let errorTemplates = this.errorTemplates;
-    let catchBoundaryMap = new Map<string, CatchBoundary>();
-
-    // always have a root level catch boundary
-    catchBoundaryMap.set(
-      "/",
-      new CatchBoundary({
-        path: "/",
-        fileUrl: catchBoundaryUrl,
-        routeStackPlaceholder,
-      }),
-    );
-
-    for (let errorTemplate of errorTemplates) {
-      let path =
-        errorTemplate.path === "/"
-          ? "/"
-          : "/" +
-            errorTemplate.path
-              .split("/")
-              .filter(Boolean)
-              .slice(0, -1)
-              .join("/");
-
-      let catchBoundary = catchBoundaryMap.get(path);
-
-      if (!catchBoundary) {
-        catchBoundary = new CatchBoundary({
-          path,
-          fileUrl: catchBoundaryUrl,
-          routeStackPlaceholder,
-        });
-
-        catchBoundaryMap.set(path, catchBoundary);
-      }
-    }
-
-    return [...catchBoundaryMap.values()];
   }
 
   get css() {
@@ -695,30 +830,14 @@ export class RSCBuilder extends Builder {
   }
 
   get root() {
-    let pages = this.pages;
-    let layouts = this.layouts;
-    let errorTemplates = this.errorTemplates;
-    let catchBoundaries = this.catchBoundaries;
-    let outerRootWrapper = this.outerRootWrapper;
-
-    let root = layouts.find((layout) => layout.path === "/");
-    let otherLayouts = layouts.filter((layout) => layout.path !== "/");
-
-    if (!root) {
-      throw new Error("No root layout");
+    return this.#applicationTree.root;
+  }
+  
+  #dumpNode(node: Node, indent: string = "") {
+    console.log(indent + node.path);
+    for (const child of node.children) {
+      this.#dumpNode(child, indent + "  ");
     }
-
-    otherLayouts.forEach((layout) => root.addChild(layout));
-    catchBoundaries.forEach((catchBoundary) => root.addChild(catchBoundary));
-    pages.forEach((page) => root.addChild(page));
-    errorTemplates.forEach((errorTemplate) => root.addChild(errorTemplate));
-
-    root.addChild(this.unauthorizedPage);
-    root.addChild(this.notFoundPage);
-
-    root.addWrapper(outerRootWrapper);
-
-    return root;
   }
 
   findPageForPath(path: string) {
@@ -738,11 +857,7 @@ export class RSCBuilder extends Builder {
       } else {
         return {
           ...acc,
-          [action.id]: {
-            id: action.id,
-            name: action.export,
-            chunks: [`${action.moduleId}:${action.export}:${action.hash}`],
-          },
+          [action.id]: action.serverManifestEntry,
         };
       }
     }, {});
@@ -763,7 +878,7 @@ export class RSCBuilder extends Builder {
           return {
             ...acc,
             [action.moduleId]: {
-              path: action.path,
+              path: action.filePath,
             },
           };
         }
@@ -824,6 +939,7 @@ let srcPaths = {
     ),
   },
   app: {
+    rootAuth: path.join(appAppPath, "auth.ts"),
     globalMiddleware: path.join(appAppPath, "middleware.ts"),
     notFound: path.join(appAppPath, "pages", "errors", "not-found.tsx"),
     unauthorized: path.join(appAppPath, "pages", "unauthorized.error.tsx"),

--- a/packages/framework/src/backend/build/plugins/server-actions-plugin.ts
+++ b/packages/framework/src/backend/build/plugins/server-actions-plugin.ts
@@ -11,10 +11,12 @@ import {
 import { getModuleId } from "../helpers/module.js";
 import { pathToLanguage } from "../helpers/languages.js";
 import { shouldIgnoreUseServer } from "../helpers/excluded.js";
+import { CompiledServerAction } from "../rsc/compiled-server-action.js";
 
 type ServerAction = {
   id: string;
   path: string;
+  virtualPath: string;
   moduleId: string;
   export: string;
 };
@@ -41,6 +43,13 @@ export function serverActionsPlugin({ builder }: { builder: RSCBuilder }) {
           return null;
         }
 
+        const prefix = process.cwd() + '/app/pages';
+        if (!path.startsWith(prefix)) {
+          return null;
+        }
+
+        let virtualPath = path.substring(prefix.length);
+
         let contents = await readFile(path, "utf-8");
         let hasUseServer = contents.includes("use server");
 
@@ -64,6 +73,7 @@ export function serverActionsPlugin({ builder }: { builder: RSCBuilder }) {
             serverActions.add({
               id: `${moduleId}#${serverFunction}`,
               path,
+              virtualPath,
               moduleId,
               export: serverFunction,
             });
@@ -113,13 +123,14 @@ export function serverActionsPlugin({ builder }: { builder: RSCBuilder }) {
           actions.forEach((action) => {
             let outputPath = path.join(fileURLToPath(cwdUrl), outputFile);
             let hash = getHash(outputFile);
-            builder.serverActionMap.set(action.id, {
+            builder.serverActionMap.set(action.id, new CompiledServerAction({
               id: action.id,
               moduleId: action.moduleId,
               hash: hash,
               path: outputPath,
-              export: action.export,
-            });
+              virtualPath: action.virtualPath,
+              "export": action.export,
+            }));
           });
         }
       });

--- a/packages/framework/src/backend/build/rsc/api.ts
+++ b/packages/framework/src/backend/build/rsc/api.ts
@@ -1,11 +1,36 @@
-export class API {
+import { AuthPolicyArray } from "../../auth/auth.js";
+import { Treeable, TreeNode } from "./tree-node.js";
+
+export class API implements Treeable {
   #path: string;
   #fileUrl: URL;
+
+  tree: TreeNode;
 
   constructor({ path, fileUrl }: { path: string; fileUrl: URL }) {
     this.#path = path;
     this.#fileUrl = fileUrl;
+
+    this.tree = new TreeNode(this);
   }
+
+  canAcceptAsChild() {
+    return false;
+  }
+
+  addChild() {
+    throw new Error("Cannot add children to API routes.");
+  }
+
+  get children() {
+    return this.tree.children.map((c) => c.value);
+  }
+
+  get parent() {
+    return this.tree.parent?.value;
+  }
+
+  // 
 
   get path() {
     return this.#path;
@@ -47,5 +72,14 @@ export class API {
 
   async preload() {
     await this.loadModule();
+  }
+  
+  async getAuthPolicy(): Promise<AuthPolicyArray> {
+    let module = await this.loadModule();
+    if (module.auth) {
+      return module.auth;
+    } else {
+      return [];
+    }
   }
 }

--- a/packages/framework/src/backend/build/rsc/compiled-server-action.ts
+++ b/packages/framework/src/backend/build/rsc/compiled-server-action.ts
@@ -1,0 +1,107 @@
+import { pathToFileURL } from "url";
+import { Node, Treeable, TreeNode } from "./tree-node.js";
+import { AuthPolicyArray } from "../../auth/auth.js";
+
+export type SerializedServerAction = {
+  id: string;
+  moduleId: string;
+  path: string;
+  virtualPath: string;
+  hash: string;
+  export: string;
+};
+
+export class CompiledServerAction implements Treeable {
+  #id: string;
+  #moduleId: string;
+  #path: string;
+  #virtualPath: string;
+  #hash: string;
+  #export: string;
+  
+  tree: TreeNode;
+
+  constructor(action: SerializedServerAction) {
+    this.#id = action.id;
+    this.#moduleId = action.moduleId;
+    this.#path = action.path;
+    this.#virtualPath = action.virtualPath;
+    this.#hash = action.hash;
+    this.#export = action.export;
+
+    this.tree = new TreeNode(this);
+  }
+  
+  get path() {
+    return this.#virtualPath + '#' + this.export;
+  }
+  
+  canAcceptAsChild(): boolean {
+    return false;
+  }
+
+  addChild() {
+    throw new Error("Cannot add children to server actions.");
+  }
+
+  get children() {
+    return this.tree.children.map((c) => c.value);
+  }
+
+  get parent() {
+    return this.tree.parent?.value;
+  }
+
+  serialize(): SerializedServerAction {
+    return {
+      id: this.#id,
+      moduleId: this.#moduleId,
+      path: this.#path,
+      virtualPath: this.#virtualPath,
+      hash: this.#hash,
+      export: this.#export
+    };
+  }
+
+  get id(): string {
+    return this.#id;
+  }
+
+  get moduleId(): string {
+    return this.#moduleId;
+  }
+
+  get filePath(): string {
+    return this.#path;
+  }
+
+  get serverManifestEntry(): {
+    id: string,
+    name: string,
+    chunks: string[]
+  } {
+    return {
+      id: this.#id,
+      name: this.#export,
+      chunks: [`${this.#moduleId}:${this.#export}:${this.#hash}`],
+    };
+  }
+
+  async preload() {
+    await import(pathToFileURL(this.#path).href);
+  }
+
+  get export(): string {
+    return this.#export;
+  }
+
+  async getAuthPolicy(): Promise<AuthPolicyArray> {
+    let actionUrl = pathToFileURL(this.filePath);
+    let module = await import(actionUrl.href);
+    if (module.auth) {
+      return module.auth;
+    } else {
+      return [];
+    }
+  }
+}

--- a/packages/framework/src/backend/build/rsc/layout.ts
+++ b/packages/framework/src/backend/build/rsc/layout.ts
@@ -1,6 +1,8 @@
 import { Generic } from "./generic.js";
 import { Node, TreeNode, Treeable } from "./tree-node.js";
 import { Wrapper } from "./wrapper.js";
+import { AuthPolicyArray } from "../../auth/auth.js"
+import { ReactNode } from "react";
 
 export class Layout implements Treeable {
   #path: string;
@@ -48,7 +50,7 @@ export class Layout implements Treeable {
 
     let isSame = child.path === this.path && child.constructor === Layout;
     let hasMatchingPath = child.path.startsWith(this.path);
-
+    
     return !alreadyHave && !isSame && hasMatchingPath;
   }
 
@@ -132,12 +134,13 @@ export class Layout implements Treeable {
     //    ]
 
     let module = await this.loadModule();
-    if (!module.default) {
+    if (!module.default && !module.auth) {
       throw new Error(`Layout for ${this.path}/ has no default export.`);
     }
 
     let layout = {
-      func: module.default,
+      // this allows for "auth only" layouts; layouts which only define new auth policies but don't actually provide a layout component.
+      func: module.default ?? (({ children }: { children: ReactNode }) => { return children }),
       requirements: ["dynamicRequest"],
       props: {},
     };
@@ -149,6 +152,15 @@ export class Layout implements Treeable {
     let routeStackPlaceholder = await this.loadRouteStackPlaceholder();
 
     return [...wrappers, layout, routeStackPlaceholder];
+  }
+
+  async getAuthPolicy(): Promise<AuthPolicyArray> {
+    let module = await this.loadModule();
+    if (module.auth) {
+      return module.auth;
+    } else {
+      return [];
+    }
   }
 
   async runMiddleware(props: {

--- a/packages/framework/src/backend/build/rsc/page.ts
+++ b/packages/framework/src/backend/build/rsc/page.ts
@@ -2,6 +2,7 @@ import { Layout } from "./layout.js";
 import "urlpattern-polyfill";
 import { Treeable, TreeNode } from "./tree-node.js";
 import { CatchBoundary } from "./catch-boundary.js";
+import { AuthPolicyArray } from "../../auth/auth.js";
 
 export class Page implements Treeable {
   #path: string;
@@ -141,6 +142,15 @@ export class Page implements Treeable {
         props: {},
       },
     ];
+  }
+
+  async getAuthPolicy(): Promise<AuthPolicyArray> {
+    let module = await this.loadModule();
+    if (module.auth) {
+      return module.auth;
+    } else {
+      return [];
+    }
   }
 
   async runMiddleware(props: {

--- a/packages/framework/src/backend/build/rsc/tree-node.ts
+++ b/packages/framework/src/backend/build/rsc/tree-node.ts
@@ -1,14 +1,17 @@
+import { AuthPolicyArray } from "../../auth/auth.js";
 import {
   pathMatches,
   pathPartialMatches,
 } from "../../runtime/helpers/routing.js";
 import { partition } from "../../utils/partition.js";
+import { API } from "./api.js";
 import { CatchBoundary } from "./catch-boundary.js";
+import { CompiledServerAction } from "./compiled-server-action.js";
 import { ErrorTemplate } from "./error-template.js";
 import { Layout } from "./layout.js";
 import { Page } from "./page.js";
 
-export type Node = Layout | CatchBoundary | Page | ErrorTemplate;
+export type Node = Layout | CatchBoundary | Page | ErrorTemplate | API | CompiledServerAction;
 
 export type Treeable = {
   path: string;
@@ -104,7 +107,7 @@ export class TreeNode {
       this.#children.push(node);
       this.#rebalanceChildrenAgainst(node);
     } else {
-      throw new Error("Could not add child to this node");
+      throw new Error(`Could not add child '${node.#value.path}' to this node '${this.#value.path}'`);
     }
   }
 

--- a/packages/framework/src/backend/proxying-request.ts
+++ b/packages/framework/src/backend/proxying-request.ts
@@ -1,0 +1,130 @@
+/**
+ * When authentication policies inspect the request, such as by calling formData(), it causes server actions to fail to bind arguments to FormData because the formData has already been read.
+ * 
+ * This implementation proxies a request and caches the first Promise<> result from those functions, so that code does not need to be aware of whether the body has already been read by an authentication policy.
+ */
+export class ProxyingRequest implements Request {
+  #original: Request;
+  #arrayBuffer: Promise<ArrayBuffer> | undefined;
+  #blob: Promise<Blob> | undefined;
+  #bytes: Promise<Uint8Array<ArrayBuffer>> | undefined;
+  #formData: Promise<FormData> | undefined;
+  #json: Promise<any> | undefined;
+  #text: Promise<string> | undefined;
+
+  constructor(original: Request) {
+    this.#original = original;
+  }
+
+  get cache(): RequestCache {
+    return this.#original.cache;
+  }
+
+  get credentials(): RequestCredentials {
+    return this.#original.credentials;
+  }
+
+  get destination(): RequestDestination {
+    return this.#original.destination;
+  }
+
+  get headers(): Headers {
+    return this.#original.headers;
+  }
+
+  get integrity(): string {
+    return this.#original.integrity;
+  }
+
+  get keepalive(): boolean {
+    return this.#original.keepalive;
+  }
+
+  get method(): string {
+    return this.#original.method;
+  }
+
+  get mode(): RequestMode {
+    return this.#original.mode;
+  }
+
+  get redirect(): RequestRedirect {
+    return this.#original.redirect;
+  }
+
+  get referrer(): string {
+    return this.#original.referrer;
+  }
+  
+  get referrerPolicy(): ReferrerPolicy {
+    return this.#original.referrerPolicy;
+  }
+  
+  get signal(): AbortSignal {
+    return this.#original.signal;
+  }
+  
+  get url(): string {
+    return this.#original.url;
+  }
+  
+  get body(): ReadableStream<Uint8Array<ArrayBuffer>> | null {
+    return this.#original.body;
+  }
+  
+  get bodyUsed(): boolean {
+    return this.#original.bodyUsed;
+  }
+  
+  clone(): Request {
+    return new ProxyingRequest(this.#original.clone());
+  }
+
+  arrayBuffer(): Promise<ArrayBuffer> {
+    if (this.#arrayBuffer) {
+       return this.#arrayBuffer;
+    }
+    this.#arrayBuffer = this.#original.arrayBuffer();
+    return this.#arrayBuffer;
+  }
+
+  blob(): Promise<Blob> {
+    if (this.#blob) {
+       return this.#blob;
+    }
+    this.#blob = this.#original.blob();
+    return this.#blob;
+  }
+
+  bytes(): Promise<Uint8Array<ArrayBuffer>> {
+    if (this.#bytes) {
+       return this.#bytes;
+    }
+    this.#bytes = this.#original.bytes();
+    return this.#bytes;
+  }
+
+  formData(): Promise<FormData> {
+    if (this.#formData) {
+       return this.#formData;
+    }
+    this.#formData = this.#original.formData();
+    return this.#formData;
+  }
+
+  json(): Promise<any> {
+    if (this.#json) {
+       return this.#json;
+    }
+    this.#json = this.#original.json();
+    return this.#json;
+  }
+
+  text(): Promise<string> {
+    if (this.#text) {
+       return this.#text;
+    }
+    this.#text = this.#original.text();
+    return this.#text;
+  }
+}

--- a/packages/framework/src/backend/runtime.ts
+++ b/packages/framework/src/backend/runtime.ts
@@ -97,12 +97,14 @@ export class Runtime {
     });
   }
 
-  unauthorizedPageRequest(request: Request) {
+  unauthorizedPageRequest(request: Request, optionalMessage: string | undefined) {
     let page = this.build
       .getBuilder("rsc")
       .findPageForPath("/__tf/errors/unauthorized");
 
     invariant(page, "Could not find unauthorized page");
+
+    // @todo: pass optionalMessage to unauthorized page somehow...
 
     return new PageRequest({
       page,

--- a/packages/framework/src/backend/runtime/action-request.ts
+++ b/packages/framework/src/backend/runtime/action-request.ts
@@ -14,38 +14,40 @@ import {
   NotFoundError,
   redirectErrorInfo,
 } from "./helpers/errors.js";
-import { CompiledAction } from "../build/builders/rsc-builder.js";
 import { pathToFileURL } from "url";
 import { getStore } from "../stores/rsc-store.js";
 import { serializeError } from "serialize-error";
 import { randomUUID } from "crypto";
+import { evaluatePolicyArray } from "./helpers/auth.js";
+import { CompiledServerAction } from "../build/rsc/compiled-server-action.js";
 
 type ServerManifest = Record<
   string,
   | {
-      id: string;
-      name: string;
-      chunks: string[];
-    }
+    id: string;
+    name: string;
+    chunks: string[];
+  }
   | undefined
 >;
 
-type ServerActionMap = Map<string, CompiledAction>;
+type ServerActionMap = Map<string, CompiledServerAction>;
 
 type Result =
   | {
-      type: "return";
-      result: unknown;
-    }
+    type: "return";
+    result: unknown;
+  }
   | {
-      type: "throw";
-      error: Error;
-    };
+    type: "throw";
+    error: Error;
+  };
 
 export class ActionRequest {
   #action: SPAAction | MPAAction;
   #request: Request;
   #runtime: Runtime;
+  #serverActionMap: ServerActionMap;
   #temporaryReferences: unknown = createTemporaryReferenceSet();
 
   #result: Result | undefined = undefined;
@@ -63,6 +65,7 @@ export class ActionRequest {
   }) {
     this.#request = request;
     this.#runtime = runtime;
+    this.#serverActionMap = serverActionMap;
 
     if (SPAAction.matches(request)) {
       this.#action = new SPAAction({
@@ -97,6 +100,11 @@ export class ActionRequest {
     let requestToRender = this.requestToRender;
     let pageRequest = this.#runtime.pageRequest(requestToRender);
 
+    const authResponse = await pageRequest.evaluateAuth();
+    if (authResponse) {
+      return authResponse;
+    }
+
     let store = getStore();
     store.assets = pageRequest.assets;
     // see comment in page request file for this mutation
@@ -112,7 +120,7 @@ export class ActionRequest {
       if (isNotFoundError(err)) {
         return this.notFoundRscResponse();
       } else if (isUnauthorizedError(err)) {
-        return this.unauthorizedRscResponse();
+        return this.unauthorizedRscResponse(undefined);
       } else if (isRedirectError(err)) {
         let { url } = redirectErrorInfo(err);
         return this.redirectResponse(url);
@@ -136,9 +144,9 @@ export class ActionRequest {
       action:
         result.type === "throw"
           ? {
-              ...result,
-              error: serializeError(result.error),
-            }
+            ...result,
+            error: serializeError(result.error),
+          }
           : result,
 
       formState,
@@ -226,6 +234,29 @@ export class ActionRequest {
   }
 
   async runAction(): Promise<Result> {
+    const authResponse = await evaluatePolicyArray(
+      this.#runtime,
+      this.#serverActionMap.get(await this.#action.id())!, 
+      {
+        type: "action",
+        request: this.#request,
+      });
+    if (!authResponse.__allow) {
+      if (authResponse.__error) {
+        console.error(authResponse.__error);
+        return {
+          type: "throw",
+          error: authResponse.__error
+        };
+      } else {
+        // @todo: figure out a way to pass the message
+        return {
+          type: "throw",
+          error: new Error("TwofoldUnauthorizedError")
+        }
+      }
+    }
+
     try {
       let result = await this.#action.runAction();
       return {
@@ -295,9 +326,10 @@ export class ActionRequest {
     return notFoundRequest.ssrResponse();
   }
 
-  private unauthorizedRscResponse() {
+  private unauthorizedRscResponse(message: string | undefined) {
     let pageRequest = this.#runtime.unauthorizedPageRequest(
       this.requestToRender,
+      message,
     );
     return pageRequest.rscResponse();
   }
@@ -305,6 +337,7 @@ export class ActionRequest {
   private unauthorizedSsrResponse() {
     let unauthorizedRequest = this.#runtime.unauthorizedPageRequest(
       this.#request,
+      undefined,
     );
     return unauthorizedRequest.ssrResponse();
   }
@@ -457,7 +490,7 @@ class SPAAction implements Action {
 
   async getAction() {
     let compiledAction = this.compiledAction;
-    let actionUrl = pathToFileURL(compiledAction.path);
+    let actionUrl = pathToFileURL(compiledAction.filePath);
     let module = await import(actionUrl.href);
     let fn = module[compiledAction.export];
 

--- a/packages/framework/src/backend/runtime/api-request.ts
+++ b/packages/framework/src/backend/runtime/api-request.ts
@@ -1,5 +1,6 @@
 import { API } from "../build/rsc/api.js";
 import { Runtime } from "../runtime.js";
+import { evaluatePolicyArray, evaluatePolicyArrayToResponse } from "./helpers/auth.js";
 import {
   isNotFoundError,
   isRedirectError,
@@ -38,6 +39,36 @@ export class APIRequest {
     let request = this.#request;
     let module = await this.#api.loadModule();
 
+    const authResponse = await evaluatePolicyArrayToResponse(
+      this.#runtime,
+      this.#api,
+      {
+        type: "api",
+        request: this.#request
+      },
+      async (error) => {
+        if (isNotFoundError(error)) {
+          return new Response("Not Found", { status: 404 });
+        } else if (isUnauthorizedError(error)) {
+          return new Response("Unauthorized", { status: 401 });
+        } else if (isRedirectError(error)) {
+          let { status, url } = redirectErrorInfo(error);
+          return new Response(null, {
+            status,
+            headers: {
+              Location: url,
+            },
+          });
+        } else {
+          console.error(error);
+          return new Response("Internal Server Error", { status: 500 })
+        }
+      },
+      async (message) => new Response(message ?? "Unauthorized", { status: 401 }));
+    if (authResponse) {
+      return authResponse;
+    }
+    
     if (module.before) {
       await module.before(this.props);
     }

--- a/packages/framework/src/backend/runtime/helpers/auth.ts
+++ b/packages/framework/src/backend/runtime/helpers/auth.ts
@@ -1,0 +1,85 @@
+import { pathToFileURL } from "node:url";
+import { API } from "../../build/rsc/api.js";
+import { Layout } from "../../build/rsc/layout.js";
+import { Page } from "../../build/rsc/page.js";
+import type { Node } from "../../build/rsc/tree-node.js"
+import { Runtime } from "../../runtime.js";
+import { allow, AuthPolicy, AuthPolicyArray, AuthPolicyProps, AuthPolicyResult, evaluatePolicy } from "../../auth/auth.js";
+import { CompiledServerAction } from "../../build/rsc/compiled-server-action.js";
+
+export async function evaluatePolicyArray(runtime: Runtime, node: Node, props: AuthPolicyProps): Promise<AuthPolicyResult> {
+  let authPolicyArrays: AuthPolicyArray[] = [];
+  let current: Node | undefined = node;
+  while (current) {
+    if (current instanceof Layout ||
+      current instanceof Page ||
+      current instanceof API ||
+      current instanceof CompiledServerAction) {
+      authPolicyArrays.push(await current.getAuthPolicy());
+    } else if (!current) {
+      console.error(current);
+      throw new Error(`Unsupported parent`);
+    }
+    current = current.parent;
+  }
+
+  if (await runtime.build.getBuilder("rsc").hasRootAuth()) {
+    let rootAuthPath = runtime.build.getBuilder("rsc").rootAuthPath;
+    let rootAuthModule = await import(pathToFileURL(rootAuthPath).href);
+    if (typeof rootAuthModule.default === 'function') {
+      authPolicyArrays.push([rootAuthModule.default]);
+    }
+  }
+
+  let effectiveAuthPolicyArray: AuthPolicy[] = [];
+  for (let i = authPolicyArrays.length - 1; i >= 0; i--) {
+    let authPolicyArray = authPolicyArrays[i];
+    if (authPolicyArray === undefined) {
+      return { __allow: false, __message: "authPolicyArrays missing element", __error: new Error("authPolicyArrays missing element") };
+    }
+    for (let k = 0; k < authPolicyArray.length; k++) {
+      let authPolicy = authPolicyArray[k];
+      if (authPolicy === undefined) {
+        return { __allow: false, __message: "authPolicy missing element", __error: new Error("authPolicy missing element") };
+      }
+      if ("__reset" in authPolicy) {
+        if (authPolicy.__reset) {
+          effectiveAuthPolicyArray = [];
+        } else {
+          return { __allow: false, __message: "authPolicy unexpected __reset value", __error: new Error("authPolicy unexpected __reset value") };
+        }
+      } else {
+        effectiveAuthPolicyArray.push(authPolicy);
+      }
+    }
+  }
+
+  for (const authPolicy of effectiveAuthPolicyArray) {
+    const authPolicyResult = await evaluatePolicy(authPolicy, props);
+    if (authPolicyResult.__allow) {
+      continue;
+    } else {
+      return authPolicyResult;
+    }
+  }
+
+  return allow();
+}
+
+export async function evaluatePolicyArrayToResponse(
+  runtime: Runtime, node: Node, props: AuthPolicyProps, createErrorResponse: (error: any) => Promise<Response>, createUnauthorizedResponse: (message: string | undefined) => Promise<Response>
+): Promise<Response | undefined> {
+  const authResult = await evaluatePolicyArray(runtime, node, props);
+  if (!authResult.__allow) {
+    if (authResult.__response) {
+      return authResult.__response;
+    } else if (authResult.__error) {
+      return await createErrorResponse(authResult.__error);
+    } else if (authResult.__message) {
+      return await createUnauthorizedResponse(authResult.__message);
+    } else {
+      return await createUnauthorizedResponse(undefined);
+    }
+  }
+  return undefined;
+}

--- a/packages/framework/src/backend/runtime/page-request.ts
+++ b/packages/framework/src/backend/runtime/page-request.ts
@@ -11,6 +11,7 @@ import { ComponentType, createElement, ReactElement } from "react";
 import { applyPathParams } from "./helpers/routing.js";
 import xxhash from "xxhash-wasm";
 import { invariant } from "../utils/invariant.js";
+import { evaluatePolicyArray, evaluatePolicyArrayToResponse } from "./helpers/auth.js";
 
 export class PageRequest {
   #page: Page;
@@ -47,7 +48,43 @@ export class PageRequest {
     return this.#page;
   }
 
+  async evaluateAuth(): Promise<Response | undefined> {
+    if (!this.#conditions.includes("unauthorized")) {
+      const authResponse = await evaluatePolicyArrayToResponse(
+        this.#runtime, 
+        this.#page, 
+        {
+          type: "page",
+          request: this.#request,
+          routeParams: this.dynamicParams,
+        },
+        async (error) => {
+          if (isNotFoundError(error)) {
+            return this.notFoundRscResponse();
+          } else if (isUnauthorizedError(error)) {
+            return this.unauthorizedRscResponse(undefined);
+          } else if (isRedirectError(error)) {
+            let { status, url } = redirectErrorInfo(error);
+            return this.redirectResponse(status, url);
+          } else {
+            console.error(error);
+            return new Response("Internal Server Error", { status: 500 })
+          }
+        },
+        async (message) => await this.unauthorizedRscResponse(message));
+      if (authResponse) {
+        return authResponse;
+      }
+    }
+    return undefined;
+  }
+
   async rscResponse(): Promise<Response> {
+    const authResponse = await this.evaluateAuth();
+    if (authResponse) {
+      return authResponse;
+    }
+
     // setup store
     let store = getStore();
     if (store) {
@@ -69,7 +106,7 @@ export class PageRequest {
       if (isNotFoundError(error)) {
         return this.notFoundRscResponse();
       } else if (isUnauthorizedError(error)) {
-        return this.unauthorizedRscResponse();
+        return this.unauthorizedRscResponse(undefined);
       } else if (isRedirectError(error)) {
         let { status, url } = redirectErrorInfo(error);
         return this.redirectResponse(status, url);
@@ -112,7 +149,7 @@ export class PageRequest {
     let rscResponse = await this.rscResponse();
 
     // response is not SSRable
-    if (!rscResponse.body) {
+    if (!rscResponse.body || rscResponse.headers.get("Content-type") !== 'text/x-component') {
       return rscResponse;
     }
 
@@ -219,9 +256,10 @@ export class PageRequest {
     return notFoundRequest.rscResponse();
   }
 
-  private unauthorizedRscResponse() {
+  private unauthorizedRscResponse(message: string | undefined) {
     let unauthorizedRequest = this.#runtime.unauthorizedPageRequest(
       this.#request,
+      message,
     );
 
     return unauthorizedRequest.rscResponse();

--- a/packages/framework/src/backend/server.ts
+++ b/packages/framework/src/backend/server.ts
@@ -18,6 +18,7 @@ import { filterRequests } from "./server/middlewares/filter-requests.js";
 import { gzip } from "./server/middlewares/gzip.js";
 import kleur from "kleur";
 import { Socket } from "net";
+import { ProxyingRequest } from "./proxying-request.js";
 
 async function createHandler(server: Server) {
   let runtime = server.runtime;
@@ -48,7 +49,9 @@ async function createHandler(server: Server) {
   app.use(requestStore(runtime));
 
   app.get("/__rsc/page", async (ctx) => {
-    let url = new URL(ctx.request.url);
+    let proxiedRequest = new ProxyingRequest(ctx.request);
+
+    let url = new URL(proxiedRequest.url);
     let path = url.searchParams.get("path");
 
     if (typeof path !== "string") {
@@ -56,16 +59,18 @@ async function createHandler(server: Server) {
     }
 
     let requestUrl = new URL(path, url);
-    let request = new Request(requestUrl, ctx.request);
+    let request = new Request(requestUrl, proxiedRequest);
     let pageRequest = runtime.pageRequest(request);
     let response = await pageRequest.rscResponse();
 
-    let initiator = ctx.request.headers.get("x-twofold-initiator");
+    let initiator = proxiedRequest.headers.get("x-twofold-initiator");
 
     if (response.status === 404) {
       log("Not found", requestUrl.pathname, "red");
     } else if (response.status === 401) {
       log("Unauthorized", requestUrl.pathname, "red");
+    } else if (response.status === 500) {
+      log("Internal Server Error", requestUrl.pathname, "red");
     } else if (response.status === 307) {
       let location = response.headers.get("location")?.split("?")[1];
       let params = new URLSearchParams(location ?? "");
@@ -84,7 +89,7 @@ async function createHandler(server: Server) {
   });
 
   app.post("/__rsc/action/:id", async (ctx) => {
-    let request = ctx.request;
+    let request = new ProxyingRequest(ctx.request);
 
     let actionRequest = runtime.actionRequest(request);
 
@@ -100,6 +105,8 @@ async function createHandler(server: Server) {
       log("Not found", `Action ${name}`, "red");
     } else if (response.status === 401) {
       log("Unauthorized", `Action ${name}`, "red");
+    } else if (response.status === 500) {
+      log("Internal Server Error", `Action ${name}`, "red");
     } else if (response.status === 303) {
       let locationHeader = response.headers.get("location");
       let location = locationHeader?.startsWith("/__rsc/page?path=")
@@ -119,7 +126,7 @@ async function createHandler(server: Server) {
   app.use(waitForSSR(runtime));
 
   app.use("/**/*", async (ctx) => {
-    let request = ctx.request;
+    let request = new ProxyingRequest(ctx.request);
     let requestUrl = new URL(request.url);
 
     let apiRequest = runtime.apiRequest(request);
@@ -143,6 +150,8 @@ async function createHandler(server: Server) {
           log("Not found", requestUrl.pathname, "red");
         } else if (response.status === 401) {
           log("Unauthorized", requestUrl.pathname, "red");
+        } else if (response.status === 500) {
+          log("Internal Server Error", requestUrl.pathname, "red");
         } else if (response.status === 307 || response.status === 308) {
           let location = response.headers.get("location");
           log(
@@ -162,7 +171,7 @@ async function createHandler(server: Server) {
 
   // mpa actions
   app.post("/**/*", async (ctx) => {
-    let request = ctx.request;
+    let request = new ProxyingRequest(ctx.request);
 
     let actionRequest = runtime.actionRequest(request);
     if (actionRequest) {
@@ -173,6 +182,8 @@ async function createHandler(server: Server) {
         log("Not found", `Action ${name}`, "red");
       } else if (response.status === 401) {
         log("Unauthorized", `Action ${name}`, "red");
+      } else if (response.status === 500) {
+        log("Internal Server Error", `Action ${name}`, "red");
       } else if (response.status === 303) {
         let location = response.headers.get("location");
         log("Redirect", `Action ${name} redirected to ${location}`, "cyan");
@@ -185,7 +196,7 @@ async function createHandler(server: Server) {
   });
 
   app.head("/**/*", async (ctx) => {
-    let request = ctx.request;
+    let request = new ProxyingRequest(ctx.request);
     let pageRequest = runtime.pageRequest(request);
     let response = await pageRequest.rscResponse();
 
@@ -201,7 +212,7 @@ async function createHandler(server: Server) {
 
   app.get("/**/*", async (ctx) => {
     let url = new URL(ctx.request.url);
-    let request = ctx.request;
+    let request = new ProxyingRequest(ctx.request);
 
     let pageRequest = runtime.pageRequest(request);
     let response = await pageRequest.ssrResponse();
@@ -210,6 +221,8 @@ async function createHandler(server: Server) {
       log("Not found", url.pathname, "red");
     } else if (response.status === 401) {
       log("Unauthorized", url.pathname, "red");
+    } else if (response.status === 500) {
+      log("Internal Server Error", url.pathname, "red");
     } else if (response.status === 307 || response.status === 308) {
       let location = response.headers.get("location");
       log("Redirect", `${url.pathname} redirected to ${location}`, "cyan");

--- a/packages/framework/src/client/http/auth.ts
+++ b/packages/framework/src/client/http/auth.ts
@@ -1,0 +1,5 @@
+export * from "../../backend/auth/auth"
+
+export function isServerActionUnauthorizedError(err: any) {
+  return err instanceof Error && "message" in err && typeof err.message === "string" && err.message.startsWith("TwofoldUnauthorizedError");
+}

--- a/packages/server-function-transforms/src/plugins/server-transform-plugin.ts
+++ b/packages/server-function-transforms/src/plugins/server-transform-plugin.ts
@@ -25,6 +25,10 @@ type State = {
   getUniqueFunctionName: (name: string) => string;
 };
 
+function shouldIgnoreExport(name: string) {
+  return (name === 'auth');
+}
+
 export function ServerTransformPlugin(
   babel: any,
   options: Options,
@@ -220,6 +224,10 @@ export function ServerTransformPlugin(
             ) {
               let exportName = specifier.exported.name;
               let localName = specifier.local.name;
+
+              if (shouldIgnoreExport(exportName)) {
+                continue;
+              }
 
               insertRegisterServerReference({
                 path,
@@ -448,6 +456,10 @@ function registerServerFunction({
 
   if (!name) {
     name = functionName;
+  }
+
+  if (shouldIgnoreExport(name)) {
+    return;
   }
 
   insertRegisterServerReference({


### PR DESCRIPTION
This implements authentication policies and resolves #135.

The only difference between this implementation and what was described in that issue, is that instead of `inherit` to make a route inherit authentication policies, you need to use `reset` to make a route *not* inherit authentication policies. This is to ensure that developers don't accidentally expose routes by forgetting to add `inherit`, when it's the common case.

This required more invasive changes than originally planned - in order to make authentication work on server actions and API endpoints, they both needed to be added to the root tree used for pages and layouts.

I also needed to modify the RSC builder to ensure that pages, layouts, API endpoints and server actions returned are the same instances that get added to the root tree. There was a case where API endpoints would be added to the root tree, but then `apiEndpoints` would return new object because those properties evaluated the new list every time. Instead, `ApplicationTree` now generates the root tree and objects, and the cached versions are returned until the application tree is recreated (due to e.g. `RSCBuilder.load` being called).

It is also important to note the following breaking changes:

- Server actions can no longer be called `auth` in files that have `"use server"`. This export is now reserved for auth policies that apply to the server actions declared in that file.
- Server actions must be declared underneath `app/`. Files outside of the `app/` directory are no longer scanned for `"use server"` because we need to be able to apply auth policies consistently.

I haven't yet figured out an API to pass the string from `deny()` through to the unauthorized page. It currently reaches `unauthorizedPageRequest` but doesn't get stashed anywhere for further retrieval.

Requests on the server are also now wrapped with `ProxyingRequest`. This request caches the promise returned by `formData()` and related functions, so that we don't get errors inside the React infrastructure for server actions if an authentication policy tries to read the request body.

I also updated the kitchen sink example to demonstrate authentication policies.

https://github.com/user-attachments/assets/04ba8823-d932-4522-bc0e-22993e7ec5b8


