### PR TITLE
Add GitHub action to run prettier format

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,0 +1,26 @@
+name: Prettier Format
+
+on:
+  pull_request:
+
+jobs:
+  format:
+    name: "Format"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+      - name: Install Packages
+        run: |
+          corepack enable
+          pnpm i --frozen-lockfile
+      - name: Prettier Action
+        uses: creyD/prettier_action@8c18391fdc98ed0d884c6345f03975edac71b8f0
+        with:
+          prettier_options: --write .
+          git_identity: author
+          clean_node_folder: false
+          commit_message: "Automatic code format with Prettier"


### PR DESCRIPTION
This adds a GitHub action that automatically runs Prettier on pull requests and pushes a new commit if there are code styling changes to apply. This helps keep code styling consistent in contributions even if people don't have "format on save" enabled in their editor.