### PR TITLE
Fix server actions that redirect when used with `useActionState`

### DIFF
--- a/examples/kitchen-sink/app/pages/routing/redirects/layout.tsx
+++ b/examples/kitchen-sink/app/pages/routing/redirects/layout.tsx
@@ -111,6 +111,14 @@ export default function Layout({ children }: { children: ReactNode }) {
               Action redirect not found
             </Link>
           </li>
+          <li>
+            <Link
+              href="/routing/redirects/server-action-redirect"
+              className="text-blue-500 underline"
+            >
+              Server action redirect
+            </Link>
+          </li>
         </ul>
       </div>
       <div>{children}</div>

--- a/examples/kitchen-sink/app/pages/routing/redirects/server-action-redirect-form.tsx
+++ b/examples/kitchen-sink/app/pages/routing/redirects/server-action-redirect-form.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useActionState } from "react";
+import { action } from "./server-action";
+
+export interface MyValue {
+  value: string | undefined;
+}
+
+const initialState: MyValue = {
+  value: "test",
+};
+
+export default function MyForm() {
+  const [state, onSubmit, pending] = useActionState(
+    () => action(true),
+    initialState,
+  );
+
+  return (
+    <form action={onSubmit}>
+      {state.value ? <div>{state.value}</div> : null}
+      <button type="submit" disabled={pending}>
+        Send Request
+      </button>
+    </form>
+  );
+}

--- a/examples/kitchen-sink/app/pages/routing/redirects/server-action-redirect.page.tsx
+++ b/examples/kitchen-sink/app/pages/routing/redirects/server-action-redirect.page.tsx
@@ -1,0 +1,14 @@
+import MyForm from "./server-action-redirect-form";
+
+export default function Page() {
+  return (
+    <div>
+      <h1 className="text-4xl font-black tracking-tighter">
+        Server action redirect
+      </h1>
+      <div className="mt-3">
+        <MyForm />
+      </div>
+    </div>
+  );
+}

--- a/examples/kitchen-sink/app/pages/routing/redirects/server-action.ts
+++ b/examples/kitchen-sink/app/pages/routing/redirects/server-action.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { redirect } from "@twofold/framework/redirect";
+import { MyValue } from "./server-action-redirect-form";
+
+export async function action(shouldRedirect: boolean): Promise<MyValue> {
+  "use server";
+  if (shouldRedirect) {
+    redirect("/routing/redirects/server-action-redirect");
+  } else {
+    return { value: "another-value" };
+  }
+}

--- a/packages/framework/src/client/apps/client/actions/call-server.ts
+++ b/packages/framework/src/client/apps/client/actions/call-server.ts
@@ -6,6 +6,7 @@ import {
   // @ts-expect-error: Could not find a declaration file for module 'react-server-dom-webpack/client'.
 } from "react-server-dom-webpack/client";
 import { deserializeError } from "serialize-error";
+import { RedirectError } from "../../../errors/redirect-error";
 
 declare global {
   interface Window {
@@ -107,7 +108,9 @@ export function callServer(id: string, args: any) {
         }
 
         if (response.redirected && window.__twofold?.navigate) {
-          window.__twofold.navigate(pathToUpdate);
+          // @note: We must reject with RedirectError here so that useActionState does not attempt to use the result and cause further code to fail (because the state would become 'undefined' otherwise). By rejecting with this error, the rendering of the component using useActionState will stop and the redirection will be handled by the RedirectBoundary component.
+          reject(new RedirectError(response.status, pathToUpdate));
+          return;
         }
       }
 


### PR DESCRIPTION
If we don't reject() from `callServer`, then the component using `useActionState` has the state value updated to `undefined`, and then it continues to attempt to render, which can cause errors because code may rely on the action state not being undefined (for example, if it is typed such that it's initial value is an object with properties).

By throwing the `RedirectError`, rendering of the component immediately stops and the `RedirectBoundary` is able to redirect the page as expected.